### PR TITLE
Fixes DatabaseError when ranking is applied with a join

### DIFF
--- a/djorm_pgfulltext/models.py
+++ b/djorm_pgfulltext/models.py
@@ -113,6 +113,11 @@ class SearchManagerMixIn(object):
                 force_unicode(query).replace("'","''")
             )
 
+            full_search_field = "%s.%s" % (
+                qn(self.model._meta.db_table),
+                qn(self.search_field)
+            )
+
             # if fields is passed, obtain a vector expression with
             # these fields. In other case, intent use of search_field if
             # exists.
@@ -122,10 +127,7 @@ class SearchManagerMixIn(object):
                 if not self.search_field:
                     raise ValueError("search_field is not specified")
 
-                search_vector = "%s.%s" % (
-                    qn(self.model._meta.db_table),
-                    qn(self.search_field)
-                )
+                search_vector = full_search_field
 
             where = " (%s) @@ (%s)" % (search_vector, ts_query)
             select_dict, order = {}, []
@@ -133,7 +135,7 @@ class SearchManagerMixIn(object):
             if rank_field:
                 select_dict[rank_field] = '%s(%s, %s, %d)' % (
                     rank_function,
-                    qn(self.search_field),
+                    full_search_field,
                     ts_query,
                     rank_normalization
                 )

--- a/djorm_pgfulltext/tests/__init__.py
+++ b/djorm_pgfulltext/tests/__init__.py
@@ -4,7 +4,7 @@ from django.utils.unittest import TestCase
 from django.utils import unittest
 from django.db import connection, transaction
 
-from .models import Person, Person2, Person3
+from .models import Person, Person2, Person3, Book
 
 class TestFts(TestCase):
     def setUp(self):
@@ -111,3 +111,10 @@ class TestFts(TestCase):
 
         qs = Person3.objects.search(query="Andrei2")
         self.assertEqual(qs.count(), 0)
+
+    def test_ranking_with_join(self):
+        book = Book.objects.create(name='Learning Python', author=self.p1)
+
+        qs = Book.objects.search(query='Learning Python', rank_field='rank').select_related('author')
+
+        self.assertEqual(qs[0].author, self.p1)

--- a/djorm_pgfulltext/tests/models.py
+++ b/djorm_pgfulltext/tests/models.py
@@ -56,7 +56,6 @@ class Person3(models.Model):
 
 class Book(models.Model):
     author = models.ForeignKey(Person)
-    #editor = models.ForeignKey(Person, null=True)
     name = models.CharField(max_length=32)
     search_index = VectorField()
 

--- a/djorm_pgfulltext/tests/models.py
+++ b/djorm_pgfulltext/tests/models.py
@@ -52,3 +52,20 @@ class Person3(models.Model):
 
     def __unicode__(self):
         return self.name
+
+
+class Book(models.Model):
+    author = models.ForeignKey(Person)
+    #editor = models.ForeignKey(Person, null=True)
+    name = models.CharField(max_length=32)
+    search_index = VectorField()
+
+    objects = SearchManager(
+        fields=('name',),
+        search_field = 'search_index',
+        auto_update_search_field = True,
+        config = 'names'
+    )
+
+    def __unicode__(self):
+        return self.name

--- a/djorm_pgfulltext/tests/sql/person.postgresql_psycopg2.sql
+++ b/djorm_pgfulltext/tests/sql/person.postgresql_psycopg2.sql
@@ -1,6 +1,8 @@
 -- Create a new text search configuration to search in person names
 -- This needs no stemming or thesaurus, only unaccent and lowercasing.
 
+create extension unaccent;
+
 create text search configuration public.names (parser='default');
 
 alter text search configuration names


### PR DESCRIPTION
If you try and search with rank_field specified and a select_related attached to your queryset you will get a "column reference "search_index" is ambiguous" DatabaseError. This corrects the error by using "tablename"."fieldname" instead of just "fieldname" in the select.
