### PR TITLE
Fix an import for django versions 1.3 and 1.4

### DIFF
--- a/djorm_pgfulltext/models.py
+++ b/djorm_pgfulltext/models.py
@@ -4,7 +4,7 @@ from itertools import repeat
 
 # Python3 compatibility
 try:
-    from django.utils.encoding import force_text as force_text
+    from django.utils.encoding import force_unicode as force_text
 except ImportError:
     from django.utils.encoding import force_text
 


### PR DESCRIPTION
Current version breaks for django 1.3 and 1.4. This fixes it. Judging from https://github.com/niwibe/djorm-ext-pgfulltext/commit/e68f26b1531a3ff6f61663394d014538467ed148#L1L5 this change, this is how it should be fixed.
