### PR TITLE
Support for abstract parent classes

### DIFF
--- a/djorm_pgfulltext/models.py
+++ b/djorm_pgfulltext/models.py
@@ -97,19 +97,19 @@ class SearchManagerMixIn(object):
         '''
         Called automatically by Django when setting up the model class.
         '''
-
-        # Attach this manager as _fts_manager in the model class.
-        if not getattr(cls, '_fts_manager', None):
-            cls._fts_manager = self
-
-        # Add 'update_search_field' instance method, that calls manager's update_search_field.
-        if not getattr(cls, 'update_search_field', None):
-            def update_search_field(self, using=None, config=None):
-                self._fts_manager.update_search_field(pk=self.pk, using=using, config=config)
-            setattr(cls, 'update_search_field', update_search_field)
-
-        if self.auto_update_search_field:
-            models.signals.post_save.connect(auto_update_search_field_handler, sender=cls)
+        if not cls._meta.abstract:
+            # Attach this manager as _fts_manager in the model class.
+            if not getattr(cls, '_fts_manager', None):
+                cls._fts_manager = self
+    
+            # Add 'update_search_field' instance method, that calls manager's update_search_field.
+            if not getattr(cls, 'update_search_field', None):
+                def update_search_field(self, using=None, config=None):
+                    self._fts_manager.update_search_field(pk=self.pk, using=using, config=config)
+                setattr(cls, 'update_search_field', update_search_field)
+    
+            if self.auto_update_search_field:
+                models.signals.post_save.connect(auto_update_search_field_handler, sender=cls)
 
         super(SearchManagerMixIn, self).contribute_to_class(cls, name)
 


### PR DESCRIPTION
We're using a shared abstract parent class for our models, where I added the search_manager for the fts. The problem was that the method contribute_to_class added all needed methods to the abstract class and saved that model internally. At updating a specific instance, there occured the exception that abstract classes don't have a pk-column, which is used to build the sql-query.
I changed the behaviour of contribute_to_class to skip abstract classes, so the methods where assigned to the final derived classes and now everything works fine.
