### PR TITLE
Fix django 1.8 support: using get_queryset instead of get_query_set

### DIFF
--- a/djorm_pgfulltext/models.py
+++ b/djorm_pgfulltext/models.py
@@ -113,11 +113,11 @@ class SearchManagerMixIn(object):
 
         super(SearchManagerMixIn, self).contribute_to_class(cls, name)
 
-    def get_query_set(self):
+    def get_queryset(self):
         return SearchQuerySet(model=self.model, using=self._db)
 
     def search(self, *args, **kwargs):
-        return self.get_query_set().search(*args, **kwargs)
+        return self.get_queryset().search(*args, **kwargs)
 
     def update_search_field(self, pk=None, config=None, using=None):
         '''


### PR DESCRIPTION
"RemovedInDjango18Warning" is raised if the get_query_set function is used because this function is deprecated in django 1.8, this is resolved by using get_queryset instead.
