### PR TITLE
Fix Python3 Support

### DIFF
--- a/djorm_pgfulltext/fields.py
+++ b/djorm_pgfulltext/fields.py
@@ -48,7 +48,7 @@ if django.VERSION[:2] >= (1,7):
     from django.db.models import Lookup
 
     def quotes(wordlist):
-        return ["%s" % adapt(x.replace("\\", "").encode('utf-8')) for x in wordlist]
+        return ["%s" % adapt(x.replace("\\", "")) for x in wordlist]
 
     def startswith(wordlist):
         return [x + ":*" for x in quotes(wordlist)]

--- a/djorm_pgfulltext/fields.py
+++ b/djorm_pgfulltext/fields.py
@@ -11,10 +11,19 @@ from django.db import models
 from psycopg2.extensions import adapt
 
 class VectorField(models.Field):
-    def __init__(self, db_index=True, default='', editable=False, null=True, serialize=False, *args, **kwargs):
-        super(VectorField, self).__init__(
-            db_index=db_index, default=default, editable=editable, null=null, serialize=serialize, *args, **kwargs
-        )
+
+    def __init__(self, *args, **kwargs):
+        kwargs['default'] = ''
+        kwargs['editable'] = False
+        kwargs['serialize'] = False
+        super(VectorField, self).__init__(*args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(VectorField, self).deconstruct()
+        del kwargs['default']
+        del kwargs['editable']
+        del kwargs['serialize']
+        return name, path, args, kwargs
 
     def db_type(self, *args, **kwargs):
         return 'tsvector'

--- a/djorm_pgfulltext/fields.py
+++ b/djorm_pgfulltext/fields.py
@@ -1,5 +1,11 @@
 # -*- coding: utf-8 -*-
 
+# Python3 string compadability
+try:
+  basestring
+except NameError:
+  basestring = str
+
 import django
 from django.db import models
 from psycopg2.extensions import adapt
@@ -61,7 +67,7 @@ if django.VERSION[:2] >= (1,7):
             lhs, lhs_params = qn.compile(self.lhs)
             rhs, rhs_params = self.process_rhs(qn, connection)
 
-            if type(rhs_params) in [str, unicode]:
+            if isinstance(rhs_params, basestring):
                 rhs_params = [rhs_params]
 
             if type(rhs_params[0]) == TSConfig:

--- a/djorm_pgfulltext/fields.py
+++ b/djorm_pgfulltext/fields.py
@@ -11,13 +11,10 @@ from django.db import models
 from psycopg2.extensions import adapt
 
 class VectorField(models.Field):
-    def __init__(self, *args, **kwargs):
-        kwargs['null'] = True
-        kwargs['default'] = ''
-        kwargs['editable'] = False
-        kwargs['serialize'] = False
-        kwargs['db_index'] = True
-        super(VectorField, self).__init__(*args, **kwargs)
+    def __init__(self, db_index=True, default='', editable=False, null=True, serialize=False, *args, **kwargs):
+        super(VectorField, self).__init__(
+            db_index=db_index, default=default, editable=editable, null=null, serialize=serialize, *args, **kwargs
+        )
 
     def db_type(self, *args, **kwargs):
         return 'tsvector'


### PR DESCRIPTION
This PR fixes 2 errors on python 3.4.1
- NameError: name 'unicode' is not defined

``` python
    def as_sql(self, qn, connection):
        lhs, lhs_params = qn.compile(self.lhs)
        rhs, rhs_params = self.process_rhs(qn, connection)

>       if type(rhs_params) in [str, unicode]:
E       NameError: name 'unicode' is not defined

../../../.virtualenvs/lovely-django/lib/python3.4/site-packages/djorm_pgfulltext/fields.py:64: NameError
```

---
- django.db.utils.ProgrammingError: syntax error in tsquery: "'programmer'::bytea"

``` python
    def execute(self, sql, params=None):
        self.db.validate_no_broken_transaction()
        self.db.set_dirty()
        with self.db.wrap_database_errors:
            if params is None:
                return self.cursor.execute(sql)
            else:
>               return self.cursor.execute(sql, params)
E               django.db.utils.ProgrammingError: syntax error in tsquery: "'programmer'::bytea"

../../../.virtualenvs/lovely-django/lib/python3.4/site-packages/django/db/backends/utils.py:65: ProgrammingError
```
