### PR TITLE
Remove db_index setting for VectorField

### DIFF
--- a/djorm_pgfulltext/fields.py
+++ b/djorm_pgfulltext/fields.py
@@ -10,7 +10,13 @@ class VectorField(models.Field):
         kwargs['default'] = ''
         kwargs['editable'] = False
         kwargs['serialize'] = False
-        kwargs['db_index'] = True
+
+        # user decides if this will be indexed or not
+        # when this is e.g. used to store tsvector type
+        # we usually don't want to use db_index=True but rather FTS index
+        # see https://github.com/djangonauts/djorm-ext-pgfulltext/issues/45
+        # kwargs['db_index'] = True
+
         super(VectorField, self).__init__(*args, **kwargs)
 
     def db_type(self, *args, **kwargs):


### PR DESCRIPTION
When VectorField is used to represent a tsvector, PostgreSQL routinely
reports that "OperationalError: index row size XXXX exceeds maximum 2712
for index 'yourfield_tsv'. In any case, you should probably use FTS
indexing with tsvectors. For these reasons, we don't hardcode db_index
and let the user decide.
