### PR TITLE
VectorField Defaults Should be Overrideable

### DIFF
--- a/djorm_pgfulltext/fields.py
+++ b/djorm_pgfulltext/fields.py
@@ -11,13 +11,10 @@ from django.db import models
 from psycopg2.extensions import adapt
 
 class VectorField(models.Field):
-    def __init__(self, *args, **kwargs):
-        kwargs['null'] = True
-        kwargs['default'] = ''
-        kwargs['editable'] = False
-        kwargs['serialize'] = False
-        kwargs['db_index'] = True
-        super(VectorField, self).__init__(*args, **kwargs)
+    def __init__(self, db_index=True, default='', editable=False, null=True, serialize=False, *args, **kwargs):
+        super(VectorField, self).__init__(
+            db_index=db_index, default=default, editable=editable, null=null, serialize=serialize, *args, **kwargs
+        )
 
     def db_type(self, *args, **kwargs):
         return 'tsvector'


### PR DESCRIPTION
Forcing defaults in VectorField makes custom field behavior nearly
impossible.  Now defaults will be optionally set, if no alternative
was provided.