### PR TITLE
Fix default behavior of VectorField

### DIFF
--- a/djorm_pgfulltext/fields.py
+++ b/djorm_pgfulltext/fields.py
@@ -11,10 +11,19 @@ from django.db import models
 from psycopg2.extensions import adapt
 
 class VectorField(models.Field):
-    def __init__(self, db_index=True, default='', editable=False, null=True, serialize=False, *args, **kwargs):
-        super(VectorField, self).__init__(
-            db_index=db_index, default=default, editable=editable, null=null, serialize=serialize, *args, **kwargs
-        )
+
+    def __init__(self, *args, **kwargs):
+        kwargs['default'] = ''
+        kwargs['editable'] = False
+        kwargs['serialize'] = False
+        super(VectorField, self).__init__(*args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(VectorField, self).deconstruct()
+        del kwargs['default']
+        del kwargs['editable']
+        del kwargs['serialize']
+        return name, path, args, kwargs
 
     def db_type(self, *args, **kwargs):
         return 'tsvector'


### PR DESCRIPTION
Per django documentation, best practice is to make changes to the __init__ method
only when setting hard defaults, or introducing new parameters.  Looking at the
original hard-set defaults, db_index and null have been removed from __init__
to allow the user to control the values for those params.  All other hard-set
params will remain, and require corresponding del entries in the deconstruct method
to allow django's migrations to work in 1.7+.