### PR TITLE
Delete Version of PBR from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = djorm-ext-pgfulltext
-version = 0.9.3
 author = Lovely Team
 author-email = engineering@livelovely.com
 summary = PostgreSQL Full Text Search integration with django orm.


### PR DESCRIPTION
Per the PBR 0.11 Release, versioning rules have been updated:
http://lists.openstack.org/pipermail/openstack-dev/2015-April/063063.html

By removing the version line in this file, pbr will manage versioning automatically
