### PR TITLE
Various fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,7 +107,7 @@ The only command you need to run the tests is:
 
 .. code-block:: bash
 
-  docker-compose run --rm djorm python3 testing/runtests.py
+  docker-compose run --rm djorm python3 testing/runtests.py djorm_pgfulltext.tests
 
 Changelog
 ---------

--- a/README.rst
+++ b/README.rst
@@ -57,8 +57,10 @@ the index field  is updated automatically by calling the ``save`` method.
 Usage examples:
 ^^^^^^^^^^^^^^^
 
-- The config parameter is optional and defaults to 'pg_catalog.english'.
-- The fields parameter is optional. If a list of tuples, you can specify the ranking of each field, if it is None, it gets 'D' as the default.
+- The ``config`` parameter is optional and defaults to ``'pg_catalog.english'``.
+- The ``config`` parameter can be a tuple as in ``('pg_catalog.english', 'pg_catalog.simple')``. In this case, all of the configs
+  are used and the tokenized vectors are joined together.
+- The ``fields`` parameter is optional. If a list of tuples, you can specify the ranking of each field, if it is ``None``, it gets ``'D'`` as the default.
 - It can also be a simple list of fields, and the ranking will be selected by default. If the field is empty, the index was applied to all fields ``CharField`` and ``TextField``.
 
 To search, use the ``search`` method of the manager. The current implementation, by default uses unaccent extension for ignore the accents. Also, the searches are case insensitive.

--- a/djorm_pgfulltext/fields.py
+++ b/djorm_pgfulltext/fields.py
@@ -8,7 +8,8 @@ except NameError:
 
 import django
 from django.db import models
-from psycopg2.extensions import adapt
+
+from djorm_pgfulltext.utils import adapt
 
 
 class VectorField(models.Field):

--- a/djorm_pgfulltext/fields.py
+++ b/djorm_pgfulltext/fields.py
@@ -50,7 +50,7 @@ except ImportError:
     pass
 
 
-if django.VERSION[:2] >= (1, 7):
+if django.VERSION >= (1, 7):
     # Create custom lookups for Django>= 1.7
 
     from django.db.models import Lookup

--- a/djorm_pgfulltext/fields.py
+++ b/djorm_pgfulltext/fields.py
@@ -78,11 +78,11 @@ if django.VERSION >= (1, 7):
                 rhs_params = [rhs_params]
 
             if type(rhs_params[0]) == TSConfig:
-                ts = rhs_params.pop(0)
+                ts = rhs_params[0]
                 ts_name = ts.name
                 cmd = '%s @@ to_tsquery(%%s::regconfig, %%s)' % lhs
 
-                rest = (ts_name, " & ".join(self.transform.__call__(rhs_params)))
+                rest = (ts_name, " & ".join(self.transform.__call__(rhs_params[1:])))
             else:
                 cmd = '%s @@ to_tsquery(%%s)' % lhs
                 rest = (" & ".join(self.transform.__call__(rhs_params)),)

--- a/djorm_pgfulltext/models.py
+++ b/djorm_pgfulltext/models.py
@@ -81,6 +81,10 @@ class SearchManagerMixIn(object):
 
     http://www.postgresql.org/docs/9.1/interactive/textsearch-configuration.html
 
+    Note that 'config' can be a tuple as in ('pg_catalog.english', 'pg_catalog.simple').
+    In this case, fields are tokenized using each of the tokenizers specified in 'config'
+    and the result is contatenated. This allows you to create tsvector with multiple configs.
+
     To do all those actions in database, create a setup sql script for Django:
 
     https://docs.djangoproject.com/en/1.4/howto/initial-data/#providing-initial-sql-data
@@ -202,15 +206,19 @@ class SearchManagerMixIn(object):
 
         return parsed_fields
 
-    def _get_search_vector(self, config, using, fields=None):
+    def _get_search_vector(self, configs, using, fields=None):
         if fields is None:
             vector_fields = self._parse_fields(self._fields)
         else:
             vector_fields = self._parse_fields(fields)
 
+        if isinstance(configs, basestring):
+            configs = [configs]
+
         search_vector = []
-        for field_name, weight in vector_fields:
-            search_vector.append(self._get_vector_for_field(field_name, weight, config, using))
+        for config in configs:
+            for field_name, weight in vector_fields:
+                search_vector.append(self._get_vector_for_field(field_name, weight, config, using))
         return ' || '.join(search_vector)
 
     def _get_vector_for_field(self, field_name, weight=None, config=None, using=None):

--- a/djorm_pgfulltext/models.py
+++ b/djorm_pgfulltext/models.py
@@ -5,6 +5,8 @@ from itertools import repeat
 from django.db import models, connections
 from django.db.models.query import QuerySet
 
+from djorm_pgfulltext.utils import adapt
+
 # Compatibility import and fixes section.
 
 try:
@@ -279,10 +281,10 @@ class SearchQuerySet(QuerySet):
 
         if query:
             function = "to_tsquery" if raw else "plainto_tsquery"
-            ts_query = "%s('%s', '%s')" % (
+            ts_query = "%s('%s', %s)" % (
                 function,
                 config,
-                psycopg2.extensions.adapt(force_text(query))
+                adapt(query)
             )
 
             full_search_field = "%s.%s" % (

--- a/djorm_pgfulltext/tests/__init__.py
+++ b/djorm_pgfulltext/tests/__init__.py
@@ -6,10 +6,10 @@ from django.db import transaction
 from django.utils import unittest
 from django.utils.unittest import TestCase
 
-from .models import Book
-from .models import Person
-from .models import Person2
-from .models import Person3
+from djorm_pgfulltext.tests.models import Book
+from djorm_pgfulltext.tests.models import Person
+from djorm_pgfulltext.tests.models import Person2
+from djorm_pgfulltext.tests.models import Person3
 
 
 class FtsSetUpMixin:
@@ -35,6 +35,8 @@ class TestFts(FtsSetUpMixin, TestCase):
         obj.update_search_field(using='default')
 
         qs = Person2.objects.search(query="Pepa")
+        self.assertEqual(qs.count(), 1)
+        qs = Person2.objects.search(query=u"Pèpâ")
         self.assertEqual(qs.count(), 1)
 
     def test_self_automatic_update_index(self):
@@ -78,10 +80,10 @@ class TestFts(FtsSetUpMixin, TestCase):
         self.assertEqual(qs2.count(), 1)
 
     def test_search_or(self):
-        qs1 = Person.objects.search(query="Andrei | Pepa", raw=True)
-        qs2 = Person.objects.search(query="Andrei | Pepo", raw=True)
-        qs3 = Person.objects.search(query="Pèpâ | Andrei", raw=True)
-        qs4 = Person.objects.search(query="Pepo | Francisco", raw=True)
+        qs1 = Person.objects.search(query=u"Andrei | Pepa", raw=True)
+        qs2 = Person.objects.search(query=u"Andrei | Pepo", raw=True)
+        qs3 = Person.objects.search(query=u"Pèpâ | Andrei", raw=True)
+        qs4 = Person.objects.search(query=u"Pepo | Francisco", raw=True)
 
         self.assertEqual(qs1.count(), 2)
         self.assertEqual(qs2.count(), 1)

--- a/djorm_pgfulltext/tests/__init__.py
+++ b/djorm_pgfulltext/tests/__init__.py
@@ -128,7 +128,7 @@ class TestFts(FtsSetUpMixin, TestCase):
 class TestFullTextLookups(FtsSetUpMixin, TestCase):
 
     def skipUnlessDjango17(self):
-        if django.VERSION[:2] < (1, 7):
+        if django.VERSION < (1, 7):
             self.skipTest("Requires Django>=1.7")
 
     def setUp(self):
@@ -147,7 +147,6 @@ class TestFullTextLookups(FtsSetUpMixin, TestCase):
                          "test       &&&& test", "\\'test"]:
             list(Person.objects.filter(search_index__ft_startswith=test_str))
 
-    @unittest.skip("Needs some love. Raises UnicodeEncodeError.")
     def test_user_input_utf8(self):
         for test_str in ["łódź"]:
             list(Person.objects.filter(search_index__ft_startswith=test_str))
@@ -155,8 +154,12 @@ class TestFullTextLookups(FtsSetUpMixin, TestCase):
     def test_alternative_config(self):
         from djorm_pgfulltext.fields import TSConfig
 
-        p = Person.objects.filter(
+        pq = Person.objects.filter(
             search_index__ft_startswith=[
-                TSConfig('names'), 'progra'])[0]
+                TSConfig('names'), 'progra'])
+        p = pq[0]
 
         self.assertEquals(p.pk, self.p1.pk)
+
+        # make sure it is preserved after re-query
+        self.assertEquals(pq.all()[0].pk, self.p1.pk)

--- a/djorm_pgfulltext/utils.py
+++ b/djorm_pgfulltext/utils.py
@@ -1,0 +1,10 @@
+import psycopg2
+
+from django.db import connection
+from django.utils.text import force_text
+
+
+def adapt(text):
+    a = psycopg2.extensions.adapt(force_text(text))
+    a.prepare(connection.connection)
+    return a

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ postgresql:
 djorm:
   build: .
   environment:
-    - POSTGRES_HOST=192.168.59.103
     - POSTGRES_USER=postgres
   links:
     - postgresql

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = djorm-ext-pgfulltext
-version = 0.9.3
+version = 0.9.4
 author = Lovely Team
 author-email = engineering@livelovely.com
 summary = PostgreSQL Full Text Search integration with django orm.

--- a/testing/runtests.py
+++ b/testing/runtests.py
@@ -9,7 +9,7 @@ from django.core.management import call_command
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
 
-if django.VERSION[:2] >= (1, 7):
+if django.VERSION >= (1, 7):
     django.setup()
 
 if __name__ == "__main__":

--- a/testing/settings.py
+++ b/testing/settings.py
@@ -14,7 +14,7 @@ DATABASES = {
         'NAME': 'test',
         'USER': os.environ.get('POSTGRES_USER', 'postgres'),
         'PASSWORD': '',
-        'HOST': os.environ.get('POSTGRES_HOST', 'localhost'),
+        'HOST': 'postgresql',
         'PORT': '',
     }
 }

--- a/testing/settings.py
+++ b/testing/settings.py
@@ -30,4 +30,8 @@ INSTALLED_APPS = (
     'djorm_pgfulltext.tests',
 )
 
-TEST_RUNNER = 'django.test.simple.DjangoTestSuiteRunner'
+import django
+if django.VERSION >= (1,6):
+    TEST_RUNNER = 'django.test.runner.DiscoverRunner'
+else:
+    TEST_RUNNER = 'django.test.simple.DjangoTestSuiteRunner'


### PR DESCRIPTION
- Fix encoding for `psycopg2.extensions.adapt` (which also fixes the skipped test)
- Get rid of `rhs_params.pop` which caused re-ran queries (with `qs.all()` to be different)
- Some tests improvements
