### PR TITLE
Fix for empty search_vector

### DIFF
--- a/djorm_pgfulltext/models.py
+++ b/djorm_pgfulltext/models.py
@@ -175,7 +175,7 @@ class SearchManagerMixIn(object):
         sql = "UPDATE %s SET %s = %s %s;" % (
             qn(self.model._meta.db_table),
             qn(search_field),
-            search_vector,
+            search_vector or "''",
             where_sql
         )
 

--- a/djorm_pgfulltext/tests/__init__.py
+++ b/djorm_pgfulltext/tests/__init__.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import django
-from django.db import connection
 from django.db import transaction
-from django.utils import unittest
 from django.utils.unittest import TestCase
 
 from djorm_pgfulltext.tests.models import Book
@@ -11,6 +9,7 @@ from djorm_pgfulltext.tests.models import Person
 from djorm_pgfulltext.tests.models import Person2
 from djorm_pgfulltext.tests.models import Person3
 from djorm_pgfulltext.tests.models import Person4
+from djorm_pgfulltext.tests.models import Person5
 
 
 class FtsSetUpMixin:
@@ -142,6 +141,14 @@ class TestFts(FtsSetUpMixin, TestCase):
 
         qs = Person4.objects.filter(data_search_index__ft_startswith="trash")
         self.assertEqual(qs.count(), 0)
+
+    def test_empty_search_index(self):
+        Person5.objects.create(
+            name='Pepa',
+            description='Is a housewife'
+        )
+
+        self.assertEqual(Person5.objects.all().count(), 1)
 
 
 class TestFullTextLookups(FtsSetUpMixin, TestCase):

--- a/djorm_pgfulltext/tests/migrations/0001_initial.py
+++ b/djorm_pgfulltext/tests/migrations/0001_initial.py
@@ -85,4 +85,17 @@ class Migration(migrations.Migration):
             },
             bases=(models.Model,),
         ),
+        migrations.CreateModel(
+            name='Person5',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(max_length=32)),
+                ('description', models.TextField()),
+                ('search_index', djorm_pgfulltext.fields.VectorField(default=b'', serialize=False, null=True, editable=False, db_index=True)),
+                ('description_search_index', djorm_pgfulltext.fields.VectorField(default=b'', serialize=False, null=True, editable=False, db_index=True)),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
     ]

--- a/djorm_pgfulltext/tests/models.py
+++ b/djorm_pgfulltext/tests/models.py
@@ -6,6 +6,7 @@ from django.db import models, connections
 from ..fields import VectorField
 from ..models import SearchManager
 
+
 class Person(models.Model):
     name = models.CharField(max_length=32)
     description = models.TextField()
@@ -99,6 +100,22 @@ class Person4(models.Model):
         return """setweight(
             to_tsvector('%s', coalesce(to_json(%s.%s::json) ->> '%s', '')), '%s')
         """ % (config, qn(field.model._meta.db_table), qn(field.column), extra['key'], weight)
+
+
+class Person5(models.Model):
+    name = models.CharField(max_length=32)
+    description = models.TextField()
+    search_index = VectorField()
+
+    objects = SearchManager(
+        fields=tuple(),
+        search_field = 'search_index',
+        config = 'names',
+        auto_update_search_field=True,
+    )
+
+    def __unicode__(self):
+        return self.name
 
 
 class Book(models.Model):


### PR DESCRIPTION
Sometimes it might happen that the search vector is empty (like when the
'search_index' tuple is empty). In this case the SQL was incorrect:
SET search_index =  WHERE ...
This commit fixes the above SQL to
SET search_index = '' WHERE ...
