### PR TITLE
resolves issue #78 for djorm_ext_pgfulltext

### DIFF
--- a/djorm_pgfulltext/utils.py
+++ b/djorm_pgfulltext/utils.py
@@ -1,10 +1,17 @@
 import psycopg2
 
-from django.db import connection
+from django.conf import settings
 from django.utils.text import force_text
 
 
 def adapt(text):
     a = psycopg2.extensions.adapt(force_text(text))
-    a.prepare(connection.connection)
+    dbconfig = getattr(settings,"DATABASES", {'default': None})['default']
+    if not dbconfig:
+        raise "'default' DATABASES connection is required in settings.py for djorm_ext_pgfulltext."
+    try:
+        pgconn= psycopg2.connect(database=dbconfig['NAME'], user=dbconfig['USER'], password=dbconfig['PASSWORD'], host=dbconfig['HOST'], port = dbconfig['PORT'])
+        a.prepare(pgconn)
+    finally:
+        pgconn.close()
     return a


### PR DESCRIPTION
default connection established with django settings credentials to psycopg2
